### PR TITLE
Only IBM JDK 7 needs the edited header files. IBM JDK 6 is able to work ...

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -44,13 +44,13 @@ endif
 
 known_os_archs := Linux-x86 Linux-x86_64 Linux-arm Linux-armhf Linux-ppc64 Mac-x86 Mac-x86_64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc SunOS-x86_64
 os_arch := $(OS_NAME)-$(OS_ARCH)
-IBM_JDK := $(findstring IBM, $(shell $(JAVA) -version 2>&1 | grep IBM))
+IBM_JDK_7 := $(findstring IBM, $(shell $(JAVA) -version 2>&1 | grep IBM | grep "JRE 1.7"))
 
 ifeq (,$(findstring $(strip $(os_arch)),$(known_os_archs)))
   os_arch := Default
 endif
 
-ifneq ($(IBM_JDK),)
+ifneq ($(IBM_JDK_7),)
   $(shell mkdir -p $(IBM_JDK_LIB))
   $(shell cp $(JAVA_HOME)/include/jniport.h $(IBM_JDK_LIB))
   $(shell sed -i "s|#define JNIEXPORT *$$|#define JNIEXPORT  __attribute__((__visibility__(\"default\")))|" $(IBM_JDK_LIB)/jniport.h)
@@ -72,7 +72,7 @@ Default_SNAPPY_FLAGS :=
 
 Linux-x86_CXX       := $(CROSS_PREFIX)g++
 Linux-x86_STRIP     := $(CROSS_PREFIX)strip
-ifeq ($(IBM_JDK),)
+ifeq ($(IBM_JDK_7),)
   Linux-x86_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden -m32
 else
   Linux-x86_CXXFLAGS  := -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden -m32
@@ -83,7 +83,7 @@ Linux-x86_SNAPPY_FLAGS:=
 
 Linux-x86_64_CXX       := $(CROSS_PREFIX)g++ 
 Linux-x86_64_STRIP     := $(CROSS_PREFIX)strip
-ifeq ($(IBM_JDK),)
+ifeq ($(IBM_JDK_7),)
   Linux-x86_64_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 
 else
   Linux-x86_64_CXXFLAGS  := -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 
@@ -94,7 +94,7 @@ Linux-x86_64_SNAPPY_FLAGS  :=
 
 Linux-ppc64_CXX       := g++
 Linux-ppc64_STRIP     := strip
-ifeq ($(IBM_JDK),)
+ifeq ($(IBM_JDK_7),)
   Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 
 else
   Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC


### PR DESCRIPTION
...with the default ones.
